### PR TITLE
Two changes to make the program more Unix-tool-like

### DIFF
--- a/mozlz4.py
+++ b/mozlz4.py
@@ -68,10 +68,14 @@ if __name__ == "__main__":
         )
     argparser.add_argument(
             "in_file",
+            nargs="?",
+            default=sys.stdin.fileno(),
             help="Path to input file."
         )
     argparser.add_argument(
             "out_file",
+            nargs="?",
+            default=sys.stdout.fileno(),
             help="Path to output file."
         )
 

--- a/mozlz4.py
+++ b/mozlz4.py
@@ -31,6 +31,7 @@
 # OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import lz4.block  # TODO: Investigate lz4.frame as alternative.
+import pathlib
 import sys
 
 from argparse import ArgumentParser
@@ -81,6 +82,12 @@ if __name__ == "__main__":
 
     parsed_args = argparser.parse_args()
 
+
+    try:
+        if pathlib.PurePath(sys.argv[0]).parts[-1].startswith("un"):
+            parsed_args.decompress = True
+    except:
+        pass
 
     try:
         in_file = open(parsed_args.in_file, "rb")


### PR DESCRIPTION
These changes allow the program to be used like a Unix filter, similar to compress/uncompress, gzip/gunzip, etc. Note that the code to allow "unmozlz4" to decompress has only been tested on Windows (of all OSes...).